### PR TITLE
Fix SAC-N walker2d configs

### DIFF
--- a/algorithms/td3_bc.py
+++ b/algorithms/td3_bc.py
@@ -341,7 +341,6 @@ class TD3_BC:  # noqa
 
         # Delayed actor updates
         if self.total_it % self.policy_freq == 0:
-
             # Compute actor loss
             pi = self.actor(state)
             q = self.critic_1(state, pi)

--- a/configs/sac_n/walker2d/medium_replay_v2.yaml
+++ b/configs/sac_n/walker2d/medium_replay_v2.yaml
@@ -6,12 +6,12 @@ checkpoints_path: null
 critic_learning_rate: 0.0003
 deterministic_torch: false
 device: cuda
-env_name: "hopper-medium-replay-v2"
+env_name: "walker2d-medium-replay-v2"
 eval_episodes: 10
 eval_every: 5
 eval_seed: 42
 gamma: 0.99
-group: "sac-n-hopper-medium-replay-v2-multiseed-v2"
+group: "sac-n-walker2d-medium-replay-v2-multiseed-v2"
 hidden_dim: 256
 log_every: 100
 max_action: 1.0

--- a/configs/sac_n/walker2d/medium_v2.yaml
+++ b/configs/sac_n/walker2d/medium_v2.yaml
@@ -6,12 +6,12 @@ checkpoints_path: null
 critic_learning_rate: 0.0003
 deterministic_torch: false
 device: cuda
-env_name: "hopper-medium-v2"
+env_name: "walker2d-medium-v2"
 eval_episodes: 10
 eval_every: 5
 eval_seed: 42
 gamma: 0.99
-group: "sac-n-hopper-medium-v2-multiseed-v2"
+group: "sac-n-walker2d-medium-v2-multiseed-v2"
 hidden_dim: 256
 log_every: 100
 max_action: 1.0


### PR DESCRIPTION
Replace 'hopper' with 'walker2d' in SAC-N walker2d configs.

Current SAC-N walker2d medium and medium-replay configs use hopper environment unexpectedly (likely copy-paste error). Corrected configs run as expected.