### PR TITLE
Decision Transformer: fixed 'reward_scale' in configs as in wandb reports

### DIFF
--- a/configs/offline/dt/halfcheetah/medium_expert_v2.yaml
+++ b/configs/offline/dt/halfcheetah/medium_expert_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [12000.0, 6000.0]
 train_seed: 10

--- a/configs/offline/dt/halfcheetah/medium_replay_v2.yaml
+++ b/configs/offline/dt/halfcheetah/medium_replay_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [12000.0, 6000.0]
 train_seed: 10

--- a/configs/offline/dt/halfcheetah/medium_v2.yaml
+++ b/configs/offline/dt/halfcheetah/medium_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [12000.0, 6000.0]
 train_seed: 10

--- a/configs/offline/dt/hopper/medium_expert_v2.yaml
+++ b/configs/offline/dt/hopper/medium_expert_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [3600.0, 1800.0]
 train_seed: 10

--- a/configs/offline/dt/hopper/medium_replay_v2.yaml
+++ b/configs/offline/dt/hopper/medium_replay_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [3600.0, 1800.0]
 train_seed: 10

--- a/configs/offline/dt/hopper/medium_v2.yaml
+++ b/configs/offline/dt/hopper/medium_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [3600.0, 1800.0]
 train_seed: 10

--- a/configs/offline/dt/walker2d/medium_expert_v2.yaml
+++ b/configs/offline/dt/walker2d/medium_expert_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [5000.0, 2500.0]
 train_seed: 10

--- a/configs/offline/dt/walker2d/medium_replay_v2.yaml
+++ b/configs/offline/dt/walker2d/medium_replay_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [5000.0, 2500.0]
 train_seed: 10

--- a/configs/offline/dt/walker2d/medium_v2.yaml
+++ b/configs/offline/dt/walker2d/medium_v2.yaml
@@ -23,7 +23,7 @@ num_layers: 3
 num_workers: 4
 project: "CORL"
 residual_dropout: 0.1
-reward_scale: 1.0
+reward_scale: 0.001
 seq_len: 20
 target_returns: [5000.0, 2500.0]
 train_seed: 10


### PR DESCRIPTION
Hiya,

Working my way through DT implementation I noticed that provided configs for locomotion tasks do not deliver perfomance as in wandb reports. Looking closely, the issue happened to be in `reward_scale` entry, namely the configs in repo had a value of `reward_scale: 1.0`, while the wandb reports ([e.g. this one](https://wandb.ai/tlab/CORL/groups/DT-hopper-medium-replay-v2-multiseed-v2/table?workspace=user-suessmann)) show `reward_scale: 0.001`.

I also ran a small-scale experiment on `hopper-medium-replay-v2`, the perfomance of an updated config matched the one you report.

<img src="https://github.com/tinkoff-ai/CORL/assets/26511522/f71e0d49-2d91-49ce-ad3f-1cb0c9a04ec1" width="500" />

